### PR TITLE
Use clang++ when cross-compiling to ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES arm64)
         ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- CFLAGS="--target=aarch64-linux-gnu --prefix=aarch64-linux-gnu-"
     )
     set(CMAKE_C_FLAGS "--target=aarch64-linux-gnu --prefix=aarch64-linux-gnu-")
+    set(CMAKE_CXX_FLAGS "--target=aarch64-linux-gnu --prefix=aarch64-linux-gnu-")
 endif()
 
 if(KFLAT_OPTS)

--- a/cmake/arm64_cross_compile.cmake
+++ b/cmake/arm64_cross_compile.cmake
@@ -9,7 +9,7 @@ if (NOT CLANG_DIR)
 endif()
 set(CMAKE_C_COMPILER ${CLANG_DIR}/bin/clang.real)
 set(CMAKE_LINKER ${CLANG_DIR}/bin/ld.lld)
-set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+set(CMAKE_CXX_COMPILER ${CLANG_DIR}/bin/clang++.real)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
Rather than introduce another dependency, use the already-provided clang++ for cross-compiling C++ client programs.